### PR TITLE
Add localization support to the package

### DIFF
--- a/resources/lang/en/vivify.php
+++ b/resources/lang/en/vivify.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+	'admin-panel'	=> 'Admin Panel',
+	'create'		=> 'Create',
+	'filter-noun'	=> 'Filter',
+	'filter-verb'	=> 'Filter',
+	'reset'			=> 'Reset',
+	'no-records'	=> 'No records found',
+	'actions'		=> 'Actions',
+	'edit'			=> 'Edit',
+	'confirmation'	=> 'Are you sure that you want to delete this row?',
+	'remove'		=> 'Remove',
+	'insert'		=> 'Insert',
+	'cancel'		=> 'Cancel',
+	'update'		=> 'Update',
+];

--- a/resources/lang/en/vivify.php
+++ b/resources/lang/en/vivify.php
@@ -14,4 +14,5 @@ return [
 	'insert'		=> 'Insert',
 	'cancel'		=> 'Cancel',
 	'update'		=> 'Update',
+	'toggle'		=> 'Toggle Navigation',
 ];

--- a/resources/lang/es/vivify.php
+++ b/resources/lang/es/vivify.php
@@ -14,4 +14,5 @@ return [
 	'insert'		=> 'Crear',
 	'cancel'		=> 'Cancelar',
 	'update'		=> 'Actualizar',
+	'toggle'		=> 'Mostrar/Ocultar Navegación',
 ];

--- a/resources/lang/es/vivify.php
+++ b/resources/lang/es/vivify.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+	'admin-panel'	=> 'Admin Panel',
+	'create'		=> 'Crear',
+	'filter-noun'	=> 'Filtro',
+	'filter-verb'	=> 'Filtrar',
+	'reset'			=> 'Reset',
+	'no-records'	=> 'No se encontraron entradas',
+	'actions'		=> 'Acciones',
+	'edit'			=> 'Editar',
+	'confirmation'	=> '¿Estás seguro de que deseas eliminar esta entrada?',
+	'remove'		=> 'Eliminar',
+	'insert'		=> 'Crear',
+	'cancel'		=> 'Cancelar',
+	'update'		=> 'Actualizar',
+];

--- a/resources/views/main-layout.blade.php
+++ b/resources/views/main-layout.blade.php
@@ -23,7 +23,7 @@
     <div class="container-fluid">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-          <span class="sr-only">Toggle Navigation</span>
+          <span class="sr-only">packageTranslation('vivify.toggle') }}</span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>

--- a/resources/views/main-layout.blade.php
+++ b/resources/views/main-layout.blade.php
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ App::getLocale() }}">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Admin panel</title>
+  <title>{{ packageTranslation('vivify.admin-panel') }}</title>
 
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
 
@@ -28,7 +28,7 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="#">Admin panel</a>
+        <a class="navbar-brand" href="#">{{ packageTranslation('vivify.admin-panel') }}</a>
       </div>
 
       <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">

--- a/resources/views/main/create.blade.php
+++ b/resources/views/main/create.blade.php
@@ -40,8 +40,8 @@
             </div>
           @endif
         @endforeach
-        <button class="btn btn-success" type="submit">Insert</button>
-        <a class="btn btn-default" href="/{{ packageConfig('prefix') }}/{{ $tableName }}">Cancel</a>
+        <button class="btn btn-success" type="submit">{{ packageTranslation('vivify.insert') }}</button>
+        <a class="btn btn-default" href="/{{ packageConfig('prefix') }}/{{ $tableName }}">{{ packageTranslation('vivify.cancel') }}</a>
       </form>
 
     </div>

--- a/resources/views/main/edit.blade.php
+++ b/resources/views/main/edit.blade.php
@@ -40,8 +40,8 @@
             </div>
           @endif
         @endforeach
-        <button class="btn btn-success" type="submit">Update</button>
-        <a class="btn btn-default" href="/{{ packageConfig('prefix') }}/{{ $tableName }}">Cancel</a>
+        <button class="btn btn-success" type="submit">{{ packageTranslation('vivify.update') }}</button>
+        <a class="btn btn-default" href="/{{ packageConfig('prefix') }}/{{ $tableName }}">{{ packageTranslation('vivify.cancel') }}</a>
       </form>
 
     </div>

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -4,12 +4,12 @@
 <div class="container-fluid">
   <div class="row">
     <div class="col-md-10 col-md-offset-1">
-      <h2>{{ ucwords(str_replace('_', ' ', str_plural($tableName))) }} <a class="btn btn-primary pull-right" href="/{{ packageConfig('prefix') }}/{{ $tableName }}/create">Create new</a></h2>
+      <h2>{{ ucwords(str_replace('_', ' ', str_plural($tableName))) }} <a class="btn btn-primary pull-right" href="/{{ packageConfig('prefix') }}/{{ $tableName }}/create">{{ packageTranslation('vivify.create') }}</a></h2>
 
       @if ($filters)
         <div class="panel panel-default">
           <div class="panel-heading">
-            <h3 class="panel-title">Filter</h3>
+            <h3 class="panel-title">{{ packageTranslation('vivify.filter-noun') }}</h3>
           </div>
           <div class="panel-body">
             <form class="form-inline" method="GET">
@@ -19,15 +19,15 @@
                   {!! Form::$options['type']($name, @$filterValue[$name], ['class'=>'form-control']) !!}
                 </div>
               @endforeach
-              <button class="btn btn-default" type="submit">Filter</button>
-              <a href="/{{ packageConfig('prefix') }}/{{ $tableName }}" class="btn btn-warning">Reset</a>
+              <button class="btn btn-default" type="submit">{{ packageTranslation('vivify.filter-verb') }}</button>
+              <a href="/{{ packageConfig('prefix') }}/{{ $tableName }}" class="btn btn-warning">{{ packageTranslation('vivify.reset') }}</a>
             </form>
           </div>
         </div>
       @endif
 
       @if (count($rows) == 0)
-        <div class="alert alert-info" role="alert">No records found</div>
+        <div class="alert alert-info" role="alert">{{ packageTranslation('vivify.no-records') }}</div>
       @else
         <table class="table table-hover">
           <thead>
@@ -53,14 +53,14 @@
 
                   <div class="btn-group">
                     <button type="button" class="btn btn-default dropdown-toggle btn-sm" data-toggle="dropdown" aria-expanded="false">
-                      Actions <span class="caret"></span>
+                      {{ packageTranslation('vivify.actions') }} <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu" role="menu">
                       <li>
-                        <a href="/{{ packageConfig('prefix') }}/{{ $tableName }}/edit/{{ $row->id }}">Edit</a>
+                        <a href="/{{ packageConfig('prefix') }}/{{ $tableName }}/edit/{{ $row->id }}">{{ packageTranslation('vivify.edit') }}</a>
                       </li>
                       <li>
-                        <a onclick="return confirm('Are you sure that you want to delete this row?')" href="/{{ packageConfig('prefix') }}/{{ $tableName }}/delete/{{ $row->id }}">Remove</a>
+                        <a onclick="return confirm('{{ packageTranslation('vivify.confirmation') }}')" href="/{{ packageConfig('prefix') }}/{{ $tableName }}/delete/{{ $row->id }}">{{ packageTranslation('vivify.remove') }}</a>
                       </li>
                     </ul>
                   </div>

--- a/src/Providers/AdminPanelGeneratorProvider.php
+++ b/src/Providers/AdminPanelGeneratorProvider.php
@@ -20,6 +20,12 @@ class AdminPanelGeneratorProvider extends ServiceProvider {
 			__DIR__ . '/../../config/' . self::PACKAGE_NAME . '.php' => config_path(self::PACKAGE_NAME . '.php'),
 		]);
 
+		$this->loadTranslationsFrom(realpath(__DIR__.'/../../resources/lang/'), self::PACKAGE_NAME);
+
+		$this->publishes([
+			realpath(__DIR__.'/../../resources/lang/') => base_path('resources/lang/vendor/' . self::PACKAGE_NAME),
+		]);
+
 		include __DIR__.'/../helpers.php';
 		include __DIR__.'/../routes.php';
 	}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -11,3 +11,8 @@ function packageView($name, $data = array())
 {
     return view(AdminPanelGeneratorProvider::PACKAGE_NAME . '::' . $name, $data);
 }
+
+function packageTranslation($key)
+{
+	return trans(AdminPanelGeneratorProvider::PACKAGE_NAME . '::' . $key);
+}


### PR DESCRIPTION
Replace all strings with a call to `trans()` and create resources for English and Spanish. The translations are published to the app in case the user wants to improve/change them.